### PR TITLE
Added injector for javax.inject.Inject annotation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.testfun</groupId>
     <artifactId>jee</artifactId>
-    <version>0.17-SNAPSHOT</version>
+    <version>0.17-novity</version>
     <packaging>jar</packaging>
 
     <parent>
@@ -66,10 +66,17 @@
         </dependency>
 
         <dependency>
+            <groupId>javax</groupId>
+            <artifactId>javaee-api</artifactId>
+            <version>7.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.jboss.spec.javax.ejb</groupId>
             <artifactId>jboss-ejb-api_3.2_spec</artifactId>
             <version>1.0.0.Final</version>
         </dependency>
+
         <dependency>
             <groupId>org.jboss.spec.javax.xml.rpc</groupId>
             <artifactId>jboss-jaxrpc-api_1.1_spec</artifactId>

--- a/src/main/java/org/testfun/jee/runner/DependencyInjector.java
+++ b/src/main/java/org/testfun/jee/runner/DependencyInjector.java
@@ -23,7 +23,8 @@ public class DependencyInjector {
                 mockRegistrar, // the MockRegistrar injector must be listed before the EJB injector to guarantee that mocks are registered before they are used.
                 new EjbInjector().withMocking(mockRegistrar),
                 new PersistenceContextInjector(),
-                new ResourceInjector().withMocking(mockRegistrar)
+                new ResourceInjector().withMocking(mockRegistrar),
+                new InjectInjector().withMocking(mockRegistrar)
         );
     }
 

--- a/src/main/java/org/testfun/jee/runner/inject/InjectInjector.java
+++ b/src/main/java/org/testfun/jee/runner/inject/InjectInjector.java
@@ -1,0 +1,19 @@
+package org.testfun.jee.runner.inject;
+
+import javax.inject.Inject;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+
+// Inject a data-source to @Inject annotated member variables with the appropriate class
+public class InjectInjector extends BaseInjector {
+    @Override
+    public Class<? extends Annotation> getAnnotation() {
+        return Inject.class;
+    }
+
+    @Override
+    public <T> void doInject(T target, Field field) {
+        final Object objectToInject = findInstanceByClass(field.getType());
+        InjectionUtils.assignObjectToField(target, field, objectToInject);
+    }
+}


### PR DESCRIPTION
Hi Michael,

I've added a simple injector for the javax.inject.Inject annotation that uses the MockRegistrar to inject mocks from the unit test case into dependencies of the rest resources having this annotation.

There is currently no factory/registry for injection of non mock dependencies like you did with the EJB part. If necessary this can easy be added, I guess.

Kind regards,

Frank